### PR TITLE
Install golang-misc so web build works on fedora

### DIFF
--- a/started/index.md
+++ b/started/index.md
@@ -104,7 +104,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 * **Debian / Ubuntu:**
 `sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev`
 * **Fedora:**
-`sudo dnf install golang gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
+`sudo dnf install golang golang-misc gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
 * **Arch Linux:**
 `sudo pacman -S go xorg-server-devel libxcursor libxrandr libxinerama libxi`
 * **Solus:**


### PR DESCRIPTION
See above. Package is split into multiple packages and the `/misc` folder that is needed to grab some js/html file for wasm can not be found without this installed. 