### PR TITLE
Add Wayland deps to install commands

### DIFF
--- a/started/index.md
+++ b/started/index.md
@@ -102,7 +102,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 
 * You will need to install Go, gcc and the graphics library header files using your package manager, one of the following commands will probably work.
 * **Debian / Ubuntu:**
-`sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev libxkbcommon-dev libwayland-dev`
+`sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev libxkbcommon-dev`
 * **Fedora:**
 `sudo dnf install golang golang-misc gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel wayland-devel`
 * **Arch Linux:**
@@ -127,7 +127,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 <div style="text-align: left" markdown="1">
 
 * You will need to install Go, gcc and the graphics library header files using the package manager.
-* `sudo apt-get install golang gcc libegl1-mesa-dev xorg-dev libxkbcommon-dev libwayland-dev`
+* `sudo apt-get install golang gcc libegl1-mesa-dev xorg-dev libxkbcommon-dev`
 
 **NOTE:** Some Wayland compositors (Gnome's compositor Mutter etc.) do not support server side decorations resulting in Fyne applications showing up without window borders. Installing `libdecor` should solve these issues. 
 

--- a/started/index.md
+++ b/started/index.md
@@ -104,7 +104,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 * **Debian / Ubuntu:**
 `sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev libxkbcommon-dev`
 * **Fedora:**
-`sudo dnf install golang golang-misc gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel`
+`sudo dnf install golang golang-misc gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel wayland-devel`
 * **Arch Linux:**
 `sudo pacman -S go xorg-server-devel libxcursor libxrandr libxinerama libxi libxkbcommon`
 * **Solus:**
@@ -118,7 +118,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 * **NixOS**
 `nix-shell -p libGL pkg-config xorg.libX11.dev xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr xorg.libXxf86vm libxkbcommon`
 
-**NOTE:** Some Wayland compositors (Gnome's compositor Mutter etc.) do not support server side decorations and Fyne applications may show up without window borders in that case. Installing `libdecor` should solve these issues. 
+**NOTE:** Some Wayland compositors (Gnome's compositor Mutter etc.) do not support server side decorations resulting in Fyne applications showing up without window borders. Installing `libdecor` should solve these issues. 
 
 </div>
 </div>

--- a/started/index.md
+++ b/started/index.md
@@ -125,7 +125,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 <div style="text-align: left" markdown="1">
 
 * You will need to install Go, gcc and the graphics library header files using the package manager.
-* `sudo apt-get install golang gcc libegl1-mesa-dev xorg-dev`
+* `sudo apt-get install golang gcc libegl1-mesa-dev xorg-dev libxkbcommon-dev libdecor-0-dev`
 
 </div>
 </div>

--- a/started/index.md
+++ b/started/index.md
@@ -127,7 +127,9 @@ The steps for installing with MSYS2 (recommended) are as follows:
 <div style="text-align: left" markdown="1">
 
 * You will need to install Go, gcc and the graphics library header files using the package manager.
-* `sudo apt-get install golang gcc libegl1-mesa-dev xorg-dev libxkbcommon-dev libdecor-0-dev`
+* `sudo apt-get install golang gcc libegl1-mesa-dev xorg-dev libxkbcommon-dev`
+
+**NOTE:** Some Wayland compositors (Gnome's compositor Mutter etc.) do not support server side decorations resulting in Fyne applications showing up without window borders. Installing `libdecor` should solve these issues. 
 
 </div>
 </div>

--- a/started/index.md
+++ b/started/index.md
@@ -112,11 +112,11 @@ The steps for installing with MSYS2 (recommended) are as follows:
 * **openSUSE:**
 `sudo zypper install go gcc libXcursor-devel libXrandr-devel Mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel`
 * **Void Linux:**
-`sudo xbps-install -S go base-devel xorg-server-devel libXrandr-devel libXcursor-devel libXinerama-devel libxkbcommon-devel`
+`sudo xbps-install -S go base-devel xorg-server-devel libXrandr-devel libXcursor-devel libXinerama-devel libxkbcommon-devel wayland-devel`
 * **Alpine Linux**
-`sudo apk add go gcc libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev linux-headers mesa-dev libxkbcommon-dev`
+`sudo apk add go gcc libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev linux-headers mesa-dev libxkbcommon-dev wayland-dev`
 * **NixOS**
-`nix-shell -p libGL pkg-config xorg.libX11.dev xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr xorg.libXxf86vm libxkbcommon`
+`nix-shell -p libGL pkg-config xorg.libX11.dev xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr xorg.libXxf86vm libxkbcommon wayland`
 
 **NOTE:** Some Wayland compositors (Gnome's compositor Mutter etc.) do not support server side decorations resulting in Fyne applications showing up without window borders. Installing `libdecor` should solve these issues. 
 

--- a/started/index.md
+++ b/started/index.md
@@ -102,21 +102,21 @@ The steps for installing with MSYS2 (recommended) are as follows:
 
 * You will need to install Go, gcc and the graphics library header files using your package manager, one of the following commands will probably work.
 * **Debian / Ubuntu:**
-`sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev`
+`sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev libxkbcommon-dev libdecor-0-dev`
 * **Fedora:**
 `sudo dnf install golang golang-misc gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel libdecor-devel`
 * **Arch Linux:**
-`sudo pacman -S go xorg-server-devel libxcursor libxrandr libxinerama libxi`
+`sudo pacman -S go xorg-server-devel libxcursor libxrandr libxinerama libxi libxkbcommon libdecor`
 * **Solus:**
-`sudo eopkg it -c system.devel golang mesalib-devel libxrandr-devel libxcursor-devel libxi-devel libxinerama-devel`
+`sudo eopkg it -c system.devel golang mesalib-devel libxrandr-devel libxcursor-devel libxi-devel libxinerama-devel libxkbcommon-devel libdecor-devel`
 * **openSUSE:**
-`sudo zypper install go gcc libXcursor-devel libXrandr-devel Mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
+`sudo zypper install go gcc libXcursor-devel libXrandr-devel Mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel libdecor-devel`
 * **Void Linux:**
-`sudo xbps-install -S go base-devel xorg-server-devel libXrandr-devel libXcursor-devel libXinerama-devel`
+`sudo xbps-install -S go base-devel xorg-server-devel libXrandr-devel libXcursor-devel libXinerama-devel libxkbcommon-devel libdecor-devel`
 * **Alpine Linux**
-`sudo apk add go gcc libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev linux-headers mesa-dev`
+`sudo apk add go gcc libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev linux-headers mesa-dev libxkbcommon-dev libdecor-dev`
 * **NixOS**
-`nix-shell -p libGL pkg-config xorg.libX11.dev xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr xorg.libXxf86vm`
+`nix-shell -p libGL pkg-config xorg.libX11.dev xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr xorg.libXxf86vm libxkbcommon libdecor`
 
 </div>
 </div>

--- a/started/index.md
+++ b/started/index.md
@@ -102,7 +102,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 
 * You will need to install Go, gcc and the graphics library header files using your package manager, one of the following commands will probably work.
 * **Debian / Ubuntu:**
-`sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev libxkbcommon-dev`
+`sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev libxkbcommon-dev libwayland-dev`
 * **Fedora:**
 `sudo dnf install golang golang-misc gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel wayland-devel`
 * **Arch Linux:**
@@ -127,7 +127,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 <div style="text-align: left" markdown="1">
 
 * You will need to install Go, gcc and the graphics library header files using the package manager.
-* `sudo apt-get install golang gcc libegl1-mesa-dev xorg-dev libxkbcommon-dev`
+* `sudo apt-get install golang gcc libegl1-mesa-dev xorg-dev libxkbcommon-dev libwayland-dev`
 
 **NOTE:** Some Wayland compositors (Gnome's compositor Mutter etc.) do not support server side decorations resulting in Fyne applications showing up without window borders. Installing `libdecor` should solve these issues. 
 

--- a/started/index.md
+++ b/started/index.md
@@ -104,7 +104,7 @@ The steps for installing with MSYS2 (recommended) are as follows:
 * **Debian / Ubuntu:**
 `sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev`
 * **Fedora:**
-`sudo dnf install golang golang-misc gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel`
+`sudo dnf install golang golang-misc gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel libdecor-devel`
 * **Arch Linux:**
 `sudo pacman -S go xorg-server-devel libxcursor libxrandr libxinerama libxi`
 * **Solus:**

--- a/started/index.md
+++ b/started/index.md
@@ -102,21 +102,23 @@ The steps for installing with MSYS2 (recommended) are as follows:
 
 * You will need to install Go, gcc and the graphics library header files using your package manager, one of the following commands will probably work.
 * **Debian / Ubuntu:**
-`sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev libxkbcommon-dev libdecor-0-dev`
+`sudo apt-get install golang gcc libgl1-mesa-dev xorg-dev libxkbcommon-dev`
 * **Fedora:**
-`sudo dnf install golang golang-misc gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel libdecor-devel`
+`sudo dnf install golang golang-misc gcc libXcursor-devel libXrandr-devel mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel`
 * **Arch Linux:**
-`sudo pacman -S go xorg-server-devel libxcursor libxrandr libxinerama libxi libxkbcommon libdecor`
+`sudo pacman -S go xorg-server-devel libxcursor libxrandr libxinerama libxi libxkbcommon`
 * **Solus:**
-`sudo eopkg it -c system.devel golang mesalib-devel libxrandr-devel libxcursor-devel libxi-devel libxinerama-devel libxkbcommon-devel libdecor-devel`
+`sudo eopkg it -c system.devel golang mesalib-devel libxrandr-devel libxcursor-devel libxi-devel libxinerama-devel libxkbcommon-devel`
 * **openSUSE:**
-`sudo zypper install go gcc libXcursor-devel libXrandr-devel Mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel libdecor-devel`
+`sudo zypper install go gcc libXcursor-devel libXrandr-devel Mesa-libGL-devel libXi-devel libXinerama-devel libXxf86vm-devel libxkbcommon-devel`
 * **Void Linux:**
-`sudo xbps-install -S go base-devel xorg-server-devel libXrandr-devel libXcursor-devel libXinerama-devel libxkbcommon-devel libdecor-devel`
+`sudo xbps-install -S go base-devel xorg-server-devel libXrandr-devel libXcursor-devel libXinerama-devel libxkbcommon-devel`
 * **Alpine Linux**
-`sudo apk add go gcc libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev linux-headers mesa-dev libxkbcommon-dev libdecor-dev`
+`sudo apk add go gcc libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev linux-headers mesa-dev libxkbcommon-dev`
 * **NixOS**
-`nix-shell -p libGL pkg-config xorg.libX11.dev xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr xorg.libXxf86vm libxkbcommon libdecor`
+`nix-shell -p libGL pkg-config xorg.libX11.dev xorg.libXcursor xorg.libXi xorg.libXinerama xorg.libXrandr xorg.libXxf86vm libxkbcommon`
+
+**NOTE:** Some Wayland compositors (Gnome's compositor Mutter etc.) do not support server side decorations and Fyne applications may show up without window borders in that case. Installing `libdecor` should solve these issues. 
 
 </div>
 </div>


### PR DESCRIPTION
# Description

Builds on #13. The idea here is to add Wayland deps everywhere so people more easily can use that support.

## Distributions to be tested:

- [x] Ubuntu / Debian
- [x] Fedora
- [x] Arch Linux
- [x] Solus
- [ ] openSUSE (build issues, see https://github.com/go-gl/glfw/issues/402)
- [ ] Void Linux
- [ ] Alpine Linux
- [ ] NixOS

## How to test:

Build a Fyne application with `-tags wayland`.