### PR TITLE
Add Linux infos to metadata

### DIFF
--- a/started/metadata.md
+++ b/started/metadata.md
@@ -10,6 +10,8 @@ information about your application in the repository.
 This file is optional, but can help to avoid having to remember specific build parameters for
 each package and release command.
 
+## Basic configuration
+
 The file should be named `FyneApp.toml` in the directory where you run the `fyne` command
 (this is normally the `main` package). The contents of the file are as follows:
 
@@ -25,9 +27,27 @@ Build = 1
 ```
 
 The top portion of the file is metadata that will be used if you upload
-your app to the https://apps.fyne.io listing page, so it is optional.
-The [Details] section contains data about your application that are used
+your app to the [Apps](https://apps.fyne.io) listing page, so it is optional.
+
+The `Details` table contains data about your application that are used
 in the release process by other app stores and operating systems.
-The fyne tool will use this file if it is found, many mandatory command parameters are not required
+
+The `fyne` tool will use this file if it is found, many mandatory command parameters are not required
 if the metadata is present. You can still override these values by using command line parameters.
 
+## Linux & BSD configuration
+
+For Linux and BSD builds there is an optional table called `LinuxAndBSD`. This table contains additional parameters for a "desktop entry" configuration file of the Fyne app. All parameters are optional, but when present they will be used by the `fyne` tool (in addition to parameters from the `Details` table).
+
+The contents of this section is as follows (with example data):
+
+```toml
+[LinuxAndBSD]
+  GenericName = "Web Browser"
+  Categories = ["Network"]
+  Comment = "View sites on the Internet"
+  Keywords = ["browser", "web"]
+  ExecParams = "-x 42"
+```
+
+Hint: For instructions on how to define these parameters correctly, please see the [Desktop Entry Specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html) from freedesktop.org.


### PR DESCRIPTION
- Add description for `LinuxAndBSD` table under "Getting Started" / "App Metadat"
- Minor formatting improvements of existing description (e.g. replace naked HTML with proper link)