### PR TITLE
fix: format string

### DIFF
--- a/binding/conversion.md
+++ b/binding/conversion.md
@@ -43,7 +43,7 @@ func main() {
 
 	f := binding.NewFloat()
 	str := binding.FloatToString(f)
-	short := binding.FloatToStringWithFormat(f, "%0.0f%%")
+	short := binding.FloatToStringWithFormat(f, "%.0f%%")
 	f.Set(25.0)
 
 	w.SetContent(container.NewVBox(


### PR DESCRIPTION
while the incorrect format string does not lead to a problem in this sample code, it would if one changes
from "widget.NewLabelWithData(short)"
to     "widget.NewEntryWithData(short)".