### PR TITLE
Collections/table: add link to API docs

### DIFF
--- a/collection/table.md
+++ b/collection/table.md
@@ -51,3 +51,5 @@ func main() {
 	myWindow.ShowAndRun()
 }
 ```
+
+For more info, for example on how to add headers to the table, see the [widget.Table API documentation](/api/v2.5/widget/table.html).


### PR DESCRIPTION
On the `collections/table` page, add a link to the `widget.Table` API documentation. This helps to give people a way forward if they want to learn more.

---

Please do check that the link URL is correct. I didn't want to upgrade the Ruby that happens to be installed on my macbook (and risk breaking things) to the version required to build this website. And I'm too unfamiliar with Ruby to know how to create some isolated test environment.

