### PR TITLE
run fyne and fyne_demo from correct repo paths

### DIFF
--- a/faq/troubleshoot.md
+++ b/faq/troubleshoot.md
@@ -13,7 +13,7 @@ Remember you can also check your configuration using the
 
 **Q: command not found: fyne**
 
-**A:** If you have installed the Fyne command using `go install fyne.io/fyne/v2/cmd/fyne@latest` but you
+**A:** If you have installed the Fyne command using `go install fyne.io/tools/cmd/fyne@latest` but you
 see an error when trying to run it then the most likely issue is that your Go install has not
 set up your PATH environment variable correctly.
 

--- a/started/demo.md
+++ b/started/demo.md
@@ -5,17 +5,17 @@ title: Run Fyne Demo
 ---
 
 If you want to see the Fyne toolkit in action before you start to code your own application,
-you can see our [demo app](https://github.com/fyne-io/fyne/tree/master/cmd/fyne_demo).
+you can see our [demo app](https://github.com/fyne-io/demo/tree/main).
 
 ### Running
 
 If you want to, you can run the demo directly using the following command (requires Go 1.16 or later):
 
-    go run fyne.io/fyne/v2/cmd/fyne_demo@latest
+    go run github.com/fyne-io/demo@latest
 
 For earlier versions of Go, you need to use the following command instead:
 
-    go run fyne.io/fyne/v2/cmd/fyne_demo
+    go run github.com/fyne-io/demo
 
 By browsing the different tabs of the app you can see all the features of Fyne toolkit.
 
@@ -25,16 +25,19 @@ It is possible to install the app as a graphical application like all others on 
 We have the helpful `fyne` tool to do this for you.
 First you will need to install the tool:
 
-	go install fyne.io/fyne/v2/cmd/fyne@latest
+	go install fyne.io/tools/cmd/fyne@latest
 
 After that you can simply package and install the demo app:
 
-	fyne get fyne.io/fyne/v2/cmd/fyne_demo
+	fyne install github.com/fyne-io/demo
+
+(This may require admin privileges on your system, and that in turn may 
+require some path changes to include the `fyne` and `go` executables.)
 
 After this step you can find "Fyne Demo" in your app launcher.
 
 ### Exploring the code
 
 If you are interested in any of the features you should  check out the
-[source code](https://github.com/fyne-io/fyne/tree/master/cmd/fyne_demo)
+[source code](https://github.com/fyne-io/demo/tree/main)
 or join one of the [community channels](https://fyne.io#contact).

--- a/started/demo.md
+++ b/started/demo.md
@@ -11,11 +11,11 @@ you can see our [demo app](https://github.com/fyne-io/demo/tree/main).
 
 If you want to, you can run the demo directly using the following command (requires Go 1.16 or later):
 
-    go run github.com/fyne-io/demo@latest
+    go run fyne.io/demo@latest
 
 For earlier versions of Go, you need to use the following command instead:
 
-    go run github.com/fyne-io/demo
+    go run fyne.io/demo
 
 By browsing the different tabs of the app you can see all the features of Fyne toolkit.
 
@@ -29,7 +29,7 @@ First you will need to install the tool:
 
 After that you can simply package and install the demo app:
 
-	fyne install github.com/fyne-io/demo
+	fyne install fyne.io/demo
 
 (This may require admin privileges on your system, and that in turn may 
 require some path changes to include the `fyne` and `go` executables.)

--- a/started/index.md
+++ b/started/index.md
@@ -212,9 +212,9 @@ If there are any problems with your installation see the [troubleshooting](/faq/
 ## Run the demo
 
 If you want to see the Fyne toolkit in action before you start to code your own application,
-you can see our [demo app](https://github.com/fyne-io/fyne/tree/master/cmd/fyne_demo) running on your computer by executing:
+you can see our [demo app](https://github.com/fyne-io/demo/tree/main) running on your computer by executing:
 
-    $ go run fyne.io/fyne_demo@latest
+    $ go run fyne.io/demo@latest
 
 Please note that the first run has to compile some C-code and can thus take longer than usual. Subsequent builds reuse the cache and will be much faster.
 
@@ -222,10 +222,10 @@ Please note that the first run has to compile some C-code and can thus take long
 
 If you want to, you can also install the demo using the following command (requires Go 1.16 or later):
 
-    $ go install fyne.io/fyne_demo@latest
+    $ go install fyne.io/demo@latest
 
 If your `GOBIN` environment has been added to path (should be by default on macOS and Windows), you can then run the demo:
 
-    $ fyne_demo
+    $ demo
 
 And that's all there is to it! Now you can write your own Fyne application in your IDE of choice. If you want to see some Fyne code in action then you can read [your first application](/started/firstapp).

--- a/started/index.md
+++ b/started/index.md
@@ -192,7 +192,7 @@ Run the following command and replace `MODULE_NAME` with your preferred module n
 You now need to download the Fyne module and helper tool. This will be done using the following commands: 
 
     $ go get fyne.io/fyne/v2@latest
-    $ go install fyne.io/fyne/v2/cmd/fyne@latest
+    $ go install fyne.io/tools/cmd/fyne@latest
 
 If you are unsure of how Go modules work, consider reading [Tutorial: Create a Go module](https://golang.org/doc/tutorial/create-module).
 
@@ -214,7 +214,7 @@ If there are any problems with your installation see the [troubleshooting](/faq/
 If you want to see the Fyne toolkit in action before you start to code your own application,
 you can see our [demo app](https://github.com/fyne-io/fyne/tree/master/cmd/fyne_demo) running on your computer by executing:
 
-    $ go run fyne.io/fyne/v2/cmd/fyne_demo@latest
+    $ go run fyne.io/fyne_demo@latest
 
 Please note that the first run has to compile some C-code and can thus take longer than usual. Subsequent builds reuse the cache and will be much faster.
 
@@ -222,7 +222,7 @@ Please note that the first run has to compile some C-code and can thus take long
 
 If you want to, you can also install the demo using the following command (requires Go 1.16 or later):
 
-    $ go install fyne.io/fyne/v2/cmd/fyne_demo@latest
+    $ go install fyne.io/fyne_demo@latest
 
 If your `GOBIN` environment has been added to path (should be by default on macOS and Windows), you can then run the demo:
 

--- a/started/packaging.md
+++ b/started/packaging.md
@@ -14,13 +14,13 @@ with Linux there are various metadata files that should get installed. What a ha
 Thankfully the "fyne" app has a "package" command that can handle this automatically. Just specifying the target OS and any required metadata (such as icon) will generate the appropriate package. The icon conversion will be done automatically for .icns or .ico so just provide a .png file :). All you need is to have the application already built for the target platform...
 
 ```
-go install fyne.io/fyne/v2/cmd/fyne@latest
+go install fyne.io/tools/cmd/fyne@latest
 fyne package -os darwin -icon myapp.png
 ```
 If you're using an older version of Go (<1.16), you should install fyne using `go get`
 
 ```
-go get fyne.io/fyne/v2/cmd/fyne
+go get fyne.io/tools/cmd/fyne
 fyne package -os darwin -icon myapp.png
 ```
 

--- a/started/webapp.md
+++ b/started/webapp.md
@@ -12,7 +12,7 @@ To prepare your app to be used over the web we use the "fyne" cli app again, whi
 "serve" command for quick testing
 
 ```
-go install fyne.io/fyne/v2/cmd/fyne@latest
+go install fyne.io/tools/cmd/fyne@latest
 fyne serve
 ```
 


### PR DESCRIPTION
Updating doc to track the move of `fyne` and `fyne_demo` out of main repo.  See issue #50.

Tracking `fyne` was straightforward, although I left the old repo path alone in the `_api/v*/upgrading.md`; I don't know when the tool actually moved.

Tracking `fyne_demo` is a bit more fraught.  
1. The server at `fyne.io` doesn't redirect to github for repo path demo, so the run command uses the path `github.com/fyne-io/demo`.  And the repo name (`demo`) doesn't match the module name (`fyne_demo`).
2. The `fyne install` command needs privilege, at least on linux, where it wants to install into `/usr/local/bin`.  
I didn't want to document using `sudo su`, but on my system, at least, the root user doesn't have `go` or `fyne` in the path, so it's the usual bash scramble to actually get the install to work.  I added some warnings in a parenthetical CYA so I wouldn't have to document the linux-specific and ugly actual sequence.

In the long run, the demo repo should be renamed and something (what?) should be done to salvage the `fyne install` command.